### PR TITLE
[Mellanox] [4700] Update platform capability file to support new breakout mode

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn4700-r0/platform.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/platform.json
@@ -413,7 +413,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp1"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp1a", "etp1b"],
-                "4x100G[50G,25G,10G,1G]": ["etp1a", "etp1b", "etp1c", "etp1d"]
+                "4x100G[50G,25G,10G,1G]": ["etp1a", "etp1b", "etp1c", "etp1d"],
+                "4x25G(4)[10G,1G]": ["etp1a", "etp1b", "etp1c", "etp1d"]
             }
         }, 
         "Ethernet8": {
@@ -422,7 +423,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp2"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp2a", "etp2b"],
-                "4x100G[50G,25G,10G,1G]": ["etp2a", "etp2b", "etp2c", "etp2d"]
+                "4x100G[50G,25G,10G,1G]": ["etp2a", "etp2b", "etp2c", "etp2d"],
+                "4x25G(4)[10G,1G]": ["etp2a", "etp2b", "etp2c", "etp2d"]
             }
         }, 
         "Ethernet16": {
@@ -431,7 +433,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp3"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp3a", "etp3b"],
-                "4x100G[50G,25G,10G,1G]": ["etp3a", "etp3b", "etp3c", "etp3d"]
+                "4x100G[50G,25G,10G,1G]": ["etp3a", "etp3b", "etp3c", "etp3d"],
+                "4x25G(4)[10G,1G]": ["etp3a", "etp3b", "etp3c", "etp3d"]
             }
         }, 
         "Ethernet24": {
@@ -440,7 +443,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp4"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp4a", "etp4b"],
-                "4x100G[50G,25G,10G,1G]": ["etp4a", "etp4b", "etp4c", "etp4d"]
+                "4x100G[50G,25G,10G,1G]": ["etp4a", "etp4b", "etp4c", "etp4d"],
+                "4x25G(4)[10G,1G]": ["etp4a", "etp4b", "etp4c", "etp4d"]
             }
         }, 
         "Ethernet32": {
@@ -449,7 +453,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp5"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp5a", "etp5b"],
-                "4x100G[50G,25G,10G,1G]": ["etp5a", "etp5b", "etp5c", "etp5d"]
+                "4x100G[50G,25G,10G,1G]": ["etp5a", "etp5b", "etp5c", "etp5d"],
+                "4x25G(4)[10G,1G]": ["etp5a", "etp5b", "etp5c", "etp5d"]
             }
         }, 
         "Ethernet40": {
@@ -458,7 +463,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp6"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp6a", "etp6b"],
-                "4x100G[50G,25G,10G,1G]": ["etp6a", "etp6b", "etp6c", "etp6d"]
+                "4x100G[50G,25G,10G,1G]": ["etp6a", "etp6b", "etp6c", "etp6d"],
+                "4x25G(4)[10G,1G]": ["etp6a", "etp6b", "etp6c", "etp6d"]
             }
         }, 
         "Ethernet48": {
@@ -467,7 +473,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp7"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp7a", "etp7b"],
-                "4x100G[50G,25G,10G,1G]": ["etp7a", "etp7b", "etp7c", "etp7d"]
+                "4x100G[50G,25G,10G,1G]": ["etp7a", "etp7b", "etp7c", "etp7d"],
+                "4x25G(4)[10G,1G]": ["etp7a", "etp7b", "etp7c", "etp7d"]
             }
         }, 
         "Ethernet56": {
@@ -476,7 +483,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp8"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp8a", "etp8b"],
-                "4x100G[50G,25G,10G,1G]": ["etp8a", "etp8b", "etp8c", "etp8d"]
+                "4x100G[50G,25G,10G,1G]": ["etp8a", "etp8b", "etp8c", "etp8d"],
+                "4x25G(4)[10G,1G]": ["etp8a", "etp8b", "etp8c", "etp8d"]
             }
         }, 
         "Ethernet64": {
@@ -485,7 +493,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp9"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp9a", "etp9b"],
-                "4x100G[50G,25G,10G,1G]": ["etp9a", "etp9b", "etp9c", "etp9d"]
+                "4x100G[50G,25G,10G,1G]": ["etp9a", "etp9b", "etp9c", "etp9d"],
+                "4x25G(4)[10G,1G]": ["etp9a", "etp9b", "etp9c", "etp9d"]
             }
         }, 
         "Ethernet72": {
@@ -494,16 +503,18 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp10"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp10a", "etp10b"],
-                "4x100G[50G,25G,10G,1G]": ["etp10a", "etp10b", "etp10c", "etp10d"]
+                "4x100G[50G,25G,10G,1G]": ["etp10a", "etp10b", "etp10c", "etp10d"],
+                "4x25G(4)[10G,1G]": ["etp10a", "etp10b", "etp10c", "etp10d"]
             }
-        }, 
+        },
         "Ethernet80": {
             "index": "11,11,11,11,11,11,11,11", 
             "lanes": "80,81,82,83,84,85,86,87", 
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp11"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp11a", "etp11b"],
-                "4x100G[50G,25G,10G,1G]": ["etp11a", "etp11b", "etp11c", "etp11d"]
+                "4x100G[50G,25G,10G,1G]": ["etp11a", "etp11b", "etp11c", "etp11d"],
+                "4x25G(4)[10G,1G]": ["etp11a", "etp11b", "etp11c", "etp11d"]
             }
         }, 
         "Ethernet88": {
@@ -512,7 +523,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp12"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp12a", "etp12b"],
-                "4x100G[50G,25G,10G,1G]": ["etp12a", "etp12b", "etp12c", "etp12d"]
+                "4x100G[50G,25G,10G,1G]": ["etp12a", "etp12b", "etp12c", "etp12d"],
+                "4x25G(4)[10G,1G]": ["etp12a", "etp12b", "etp12c", "etp12d"]
             }
         }, 
         "Ethernet96": {
@@ -521,7 +533,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp13"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp13a", "etp13b"],
-                "4x100G[50G,25G,10G,1G]": ["etp13a", "etp13b", "etp13c", "etp13d"]
+                "4x100G[50G,25G,10G,1G]": ["etp13a", "etp13b", "etp13c", "etp13d"],
+                "4x25G(4)[10G,1G]": ["etp13a", "etp13b", "etp13c", "etp13d"]
             }
         }, 
         "Ethernet104": {
@@ -530,7 +543,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp14"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp14a", "etp14b"],
-                "4x100G[50G,25G,10G,1G]": ["etp14a", "etp14b", "etp14c", "etp14d"]
+                "4x100G[50G,25G,10G,1G]": ["etp14a", "etp14b", "etp14c", "etp14d"],
+                "4x25G(4)[10G,1G]": ["etp14a", "etp14b", "etp14c", "etp14d"]
             }
         }, 
         "Ethernet112": {
@@ -539,7 +553,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp15"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp15a", "etp15b"],
-                "4x100G[50G,25G,10G,1G]": ["etp15a", "etp15b", "etp15c", "etp15d"]
+                "4x100G[50G,25G,10G,1G]": ["etp15a", "etp15b", "etp15c", "etp15d"],
+                "4x25G(4)[10G,1G]": ["etp15a", "etp15b", "etp15c", "etp15d"]
             }
         }, 
         "Ethernet120": {
@@ -548,7 +563,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp16"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp16a", "etp16b"],
-                "4x100G[50G,25G,10G,1G]": ["etp16a", "etp16b", "etp16c", "etp16d"]
+                "4x100G[50G,25G,10G,1G]": ["etp16a", "etp16b", "etp16c", "etp16d"],
+                "4x25G(4)[10G,1G]": ["etp16a", "etp16b", "etp16c", "etp16d"]
             }
         }, 
         "Ethernet128": {
@@ -557,7 +573,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp17"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp17a", "etp17b"],
-                "4x100G[50G,25G,10G,1G]": ["etp17a", "etp17b", "etp17c", "etp17d"]
+                "4x100G[50G,25G,10G,1G]": ["etp17a", "etp17b", "etp17c", "etp17d"],
+                "4x25G(4)[10G,1G]": ["etp17a", "etp17b", "etp17c", "etp17d"]
             }
         }, 
         "Ethernet136": {
@@ -566,7 +583,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp18"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp18a", "etp18b"],
-                "4x100G[50G,25G,10G,1G]": ["etp18a", "etp18b", "etp18c", "etp18d"]
+                "4x100G[50G,25G,10G,1G]": ["etp18a", "etp18b", "etp18c", "etp18d"],
+                "4x25G(4)[10G,1G]": ["etp18a", "etp18b", "etp18c", "etp18d"]
             }
         }, 
         "Ethernet144": {
@@ -575,7 +593,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp19"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp19a", "etp19b"],
-                "4x100G[50G,25G,10G,1G]": ["etp19a", "etp19b", "etp19c", "etp19d"]
+                "4x100G[50G,25G,10G,1G]": ["etp19a", "etp19b", "etp19c", "etp19d"],
+                "4x25G(4)[10G,1G]": ["etp19a", "etp19b", "etp19c", "etp19d"]
             }
         }, 
         "Ethernet152": {
@@ -584,7 +603,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp20"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp20a", "etp20b"],
-                "4x100G[50G,25G,10G,1G]": ["etp20a", "etp20b", "etp20c", "etp20d"]
+                "4x100G[50G,25G,10G,1G]": ["etp20a", "etp20b", "etp20c", "etp20d"],
+                "4x25G(4)[10G,1G]": ["etp20a", "etp20b", "etp20c", "etp20d"]
             }
         }, 
         "Ethernet160": {
@@ -593,7 +613,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp21"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp21a", "etp21b"],
-                "4x100G[50G,25G,10G,1G]": ["etp21a", "etp21b", "etp21c", "etp21d"]
+                "4x100G[50G,25G,10G,1G]": ["etp21a", "etp21b", "etp21c", "etp21d"],
+                "4x25G(4)[10G,1G]": ["etp21a", "etp21b", "etp21c", "etp21d"]
             }
         }, 
         "Ethernet168": {
@@ -602,7 +623,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp22"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp22a", "etp22b"],
-                "4x100G[50G,25G,10G,1G]": ["etp22a", "etp22b", "etp22c", "etp22d"]
+                "4x100G[50G,25G,10G,1G]": ["etp22a", "etp22b", "etp22c", "etp22d"],
+                "4x25G(4)[10G,1G]": ["etp22a", "etp22b", "etp22c", "etp22d"]
             }
         }, 
         "Ethernet176": {
@@ -611,7 +633,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp23"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp23a", "etp23b"],
-                "4x100G[50G,25G,10G,1G]": ["etp23a", "etp23b", "etp23c", "etp23d"]
+                "4x100G[50G,25G,10G,1G]": ["etp23a", "etp23b", "etp23c", "etp23d"],
+                "4x25G(4)[10G,1G]": ["etp23a", "etp23b", "etp23c", "etp23d"]
             }
         }, 
         "Ethernet184": {
@@ -620,7 +643,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp24"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp24a", "etp24b"],
-                "4x100G[50G,25G,10G,1G]": ["etp24a", "etp24b", "etp24c", "etp24d"]
+                "4x100G[50G,25G,10G,1G]": ["etp24a", "etp24b", "etp24c", "etp24d"],
+                "4x25G(4)[10G,1G]": ["etp24a", "etp24b", "etp24c", "etp24d"]
             }
         }, 
         "Ethernet192": {
@@ -629,7 +653,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp25"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp25a", "etp25b"],
-                "4x100G[50G,25G,10G,1G]": ["etp25a", "etp25b", "etp25c", "etp25d"]
+                "4x100G[50G,25G,10G,1G]": ["etp25a", "etp25b", "etp25c", "etp25d"],
+                "4x25G(4)[10G,1G]": ["etp25a", "etp25b", "etp25c", "etp25d"]
             }
         }, 
         "Ethernet200": {
@@ -638,7 +663,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp26"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp26a", "etp26b"],
-                "4x100G[50G,25G,10G,1G]": ["etp26a", "etp26b", "etp26c", "etp26d"]
+                "4x100G[50G,25G,10G,1G]": ["etp26a", "etp26b", "etp26c", "etp26d"],
+                "4x25G(4)[10G,1G]": ["etp26a", "etp26b", "etp26c", "etp26d"]
             }
         }, 
         "Ethernet208": {
@@ -647,7 +673,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp27"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp27a", "etp27b"],
-                "4x100G[50G,25G,10G,1G]": ["etp27a", "etp27b", "etp27c", "etp27d"]
+                "4x100G[50G,25G,10G,1G]": ["etp27a", "etp27b", "etp27c", "etp27d"],
+                "4x25G(4)[10G,1G]": ["etp27a", "etp27b", "etp27c", "etp27d"]
             }
         }, 
         "Ethernet216": {
@@ -656,7 +683,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp28"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp28a", "etp28b"],
-                "4x100G[50G,25G,10G,1G]": ["etp28a", "etp28b", "etp28c", "etp28d"]
+                "4x100G[50G,25G,10G,1G]": ["etp28a", "etp28b", "etp28c", "etp28d"],
+                "4x25G(4)[10G,1G]": ["etp28a", "etp28b", "etp28c", "etp28d"]
             }
         }, 
         "Ethernet224": {
@@ -665,7 +693,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp29"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp29a", "etp29b"],
-                "4x100G[50G,25G,10G,1G]": ["etp29a", "etp29b", "etp29c", "etp29d"]
+                "4x100G[50G,25G,10G,1G]": ["etp29a", "etp29b", "etp29c", "etp29d"],
+                "4x25G(4)[10G,1G]": ["etp29a", "etp29b", "etp29c", "etp29d"]
             }
         }, 
         "Ethernet232": {
@@ -674,7 +703,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp30"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp30a", "etp30b"],
-                "4x100G[50G,25G,10G,1G]": ["etp30a", "etp30b", "etp30c", "etp30d"]
+                "4x100G[50G,25G,10G,1G]": ["etp30a", "etp30b", "etp30c", "etp30d"],
+                "4x25G(4)[10G,1G]": ["etp30a", "etp30b", "etp30c", "etp30d"]
             }
         }, 
         "Ethernet240": {
@@ -683,7 +713,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp31"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp31a", "etp31b"],
-                "4x100G[50G,25G,10G,1G]": ["etp31a", "etp31b", "etp31c", "etp31d"]
+                "4x100G[50G,25G,10G,1G]": ["etp31a", "etp31b", "etp31c", "etp31d"],
+                "4x25G(4)[10G,1G]": ["etp31a", "etp31b", "etp31c", "etp31d"]
             }
         }, 
         "Ethernet248": {
@@ -692,7 +723,8 @@
             "breakout_modes": {
                 "1x400G[200G,100G,50G,40G,25G,10G,1G]": ["etp32"],
                 "2x200G[100G,50G,40G,25G,10G,1G]": ["etp32a", "etp32b"],
-                "4x100G[50G,25G,10G,1G]": ["etp32a", "etp32b", "etp32c", "etp32d"]
+                "4x100G[50G,25G,10G,1G]": ["etp32a", "etp32b", "etp32c", "etp32d"],
+                "4x25G(4)[10G,1G]": ["etp32a", "etp32b", "etp32c", "etp32d"]
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

This new breakout mode is required when a QSFP cable is used on the QSFP-DD supported 4700 port. since QSFP only uses the first 4 lanes, this mode is required to restrict the child ports to only use the first four lanes

#### How I did it

#### How to verify it

Tested on one port:
```
root@msn-4700:/home/admin# show int status
  Interface                            Lanes    Speed    MTU    FEC    Alias    Vlan    Oper    Admin                                             Type    Asym PFC
-----------  -------------------------------  -------  -----  -----  -------  ------  ------  -------  -----------------------------------------------  ----------
  Ethernet0                                0      25G   9100    N/A    etp1a  routed      up       up                                  QSFP28 or later         N/A
  Ethernet1                                1      25G   9100    N/A    etp1b  routed    down       up                                              N/A         N/A
  Ethernet2                                2      25G   9100    N/A    etp1c  routed    down       up                                              N/A         N/A
  Ethernet3                                3      25G   9100    N/A    etp1d  routed    down       up                                              N/A         N/A

```
#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

