### PR TITLE
[sonic_py_common] Cache Static Information in device_info to speed up CLI response

### DIFF
--- a/src/sonic-py-common/sonic_py_common/device_info.py
+++ b/src/sonic-py-common/sonic_py_common/device_info.py
@@ -40,8 +40,8 @@ CHASSIS_INFO_MODEL_FIELD = 'model'
 CHASSIS_INFO_REV_FIELD = 'revision'
 
 # Cacheable Objects
-sonic_ver_info = None
-is_chassis_type = None
+sonic_ver_info = {}
+hw_info_dict = {}
 
 def get_localhost_info(field, config_db=None):
     try:
@@ -361,9 +361,12 @@ def get_platform_info(config_db=None):
     """
     This function is used to get the HW info helper function
     """
-    from .multi_asic import get_num_asics
+    global hw_info_dict
 
-    hw_info_dict = {}
+    if hw_info_dict:
+        return hw_info_dict
+
+    from .multi_asic import get_num_asics
 
     version_info = get_sonic_version_info()
 
@@ -444,10 +447,7 @@ def is_packet_chassis():
 
 
 def is_chassis():
-    global is_chassis_type
-    if is_chassis_type is None:
-        is_chassis_type = is_voq_chassis() or is_packet_chassis()
-    return is_chassis_type
+    return is_voq_chassis() or is_packet_chassis()
 
 
 def is_supervisor():


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Profiled the execution for the following cmd `intfutil -c status `

**Before Optimization:**
```
root@msn-2410:/home/admin# time intfutil -c status
...................
...................
real    0m1.619s
user    0m1.221s
sys     0m0.203s

root@msn-2410:/home/admin#python3 -m cProfile -s tottime /usr/local/bin/intfutil -c status
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      124    0.007    0.000    1.318    0.011 device_info.py:353(get_platform_info)
      124    0.002    0.000    0.890    0.007 device_info.py:332(get_sonic_version_info)
      128    0.002    0.000    0.202    0.002 device_info.py:42(get_localhost_info)
      128    0.001    0.000    0.203    0.002 device_info.py:128(get_hwsku)
       62    0.000    0.000    0.014    0.000 device_info.py:449(is_chassis)

```

**After Optimization:**
```
root@msn-2410:/home/admin# time intfutil -c status
...................
...................
real    0m0.883s
user    0m0.622s
sys     0m0.128s

root@msn-2410:/home/admin#python3 -m cProfile -s tottime /usr/local/bin/intfutil -c status
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      124    0.000    0.000    0.013    0.000 device_info.py:360(get_platform_info)
        1    0.000    0.000    0.009    0.009 device_info.py:336(get_sonic_version_info)
        5    0.000    0.000    0.008    0.002 device_info.py:46(get_localhost_info)
        5    0.000    0.000    0.008    0.002 device_info.py:132(get_hwsku)
       62    0.000    0.000    0.015    0.000 device_info.py:446(is_chassis)
```

#### How I did it

1) Cached the following information:
    - get_sonic_version_info()
    - get_platform_info()
 2) None of the API exposed to the user libraries has been modified

These methods involve reading text files or from redis. Thus, caching helped to improve the execution time

#### How to verify it

- Added UT's.
- Verified on the device

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [x] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

