### PR TITLE
[Build] Fix the installer conf file location according to the updated onie-mk-demo script  

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -71,12 +71,12 @@ generate_onie_installer_image()
     output_file=$OUTPUT_ONIE_IMAGE
     [ -n "$1" ] && output_file=$1
     # Copy platform-specific ONIE installer config files where onie-mk-demo.sh expects them
-    rm -rf ./installer/${TARGET_PLATFORM}/platforms/
-    mkdir -p ./installer/${TARGET_PLATFORM}/platforms/
+    rm -rf ./installer/platforms/
+    mkdir -p ./installer/platforms/
     for VENDOR in `ls ./device`; do
         for PLATFORM in `ls ./device/$VENDOR | grep ^${TARGET_PLATFORM}`; do
             if [ -f ./device/$VENDOR/$PLATFORM/installer.conf ]; then
-                cp ./device/$VENDOR/$PLATFORM/installer.conf ./installer/${TARGET_PLATFORM}/platforms/$PLATFORM
+                cp ./device/$VENDOR/$PLATFORM/installer.conf ./installer/platforms/$PLATFORM
             fi
 
         done


### PR DESCRIPTION
Signed-off-by: Vivek Reddy Karri <vkarri@nvidia.com>

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

***.bin image structure in 202205:** 
```
vkarri@19d5638dde2d:/sonic$ ls -l  /tmp/tmp.jyuZXWEkTC/installer/
total 1363776
-rw-r--r-- 1 vkarri dip 1396439962 Oct 13 21:44 fs.zip
-rwxr-xr-x 1 vkarri dip      24419 Oct 13 21:44 install.sh
-rw-r--r-- 1 vkarri dip         45 Oct 13 21:44 machine.conf
-rw-r--r-- 1 vkarri dip       1192 Oct 13 21:44 onie-image-arm64.conf
-rw-r--r-- 1 vkarri dip       1192 Oct 13 21:44 onie-image-armhf.conf
-rw-r--r-- 1 vkarri dip       1402 Oct 13 21:44 onie-image.conf
-rw-r--r-- 1 vkarri dip          0 Oct 13 21:44 platform.conf
drwxr-xr-x 2 vkarri dip      12288 Oct 13 21:44 platforms
-rw-r--r-- 1 vkarri dip        541 Oct 13 21:44 platforms_asic
drwxr-xr-x 2 vkarri dip       4096 Oct 13 21:44 tests
```

***.bin image structure in master:** 
```
vkarri@19d5638dde2d:/sonic$ ls -l  /tmp/tmp.9ibWSipeRw/installer                                            
total 1430908
-rwxr-xr-x 1 vkarri dip      18134 Oct 14 13:16 default_platform.conf
-rw-r--r-- 1 vkarri dip 1465188581 Oct 14 13:16 fs.zip
-rwxr-xr-x 1 vkarri dip       7641 Oct 14 13:16 install.sh
-rw-r--r-- 1 vkarri dip         45 Oct 14 13:16 machine.conf
-rw-r--r-- 1 vkarri dip       1402 Oct 14 13:16 onie-image.conf
-rw-r--r-- 1 vkarri dip          0 Oct 14 13:16 platform.conf
-rw-r--r-- 1 vkarri dip        541 Oct 14 13:16 platforms_asic
-rw-r--r-- 1 vkarri dip       1912 Oct 14 13:16 sharch_body.sh
drwxr-xr-x 2 vkarri dip       4096 Oct 14 13:16 tests
drwxr-xr-x 3 vkarri dip       4096 Oct 14 13:16 x86_64

vkarri@19d5638dde2d:/sonic$ ls -l /tmp/tmp.9ibWSipeRw/installer/x86_64/
total 12
drwxr-xr-x 2 vkarri dip 12288 Oct 14 13:16 platforms
```

However install.sh which runs on ONiE parition expects the platform specific kernel cmd line conf file under platform/$onie_platform_string file https://github.com/sonic-net/sonic-buildimage/blob/master/installer/install.sh#L102 

Thus, any platform which defines and depends on these params might be broken on master label.

#### How I did it

Since we are already filtering the conf files based on TARGET_PLATFORM in build_image.sh, i've just updated the location to `installer/platforms` instead of `installer/$arch/platforms` 

#### How to verify it

**Verified on the image after the change:**
```
root@r-bulldog-03:/home/admin# extract=1 bash sonic-mellanox.bin
Verifying image checksum ... OK.
Preparing image archive ... OK.
Image extracted to: /tmp/tmp.EjNyiJewuC
To un-mount the tmpfs when finished type:  umount /tmp/tmp.EjNyiJewuC
root@r-bulldog-03:/home/admin# ls -l /tmp/tmp.EjNyiJewuC/installer/
total 1350164
-rwxr-xr-x 1 7331 dip      18134 Oct 14 23:27 default_platform.conf
-rw-r--r-- 1 7331 dip 1382519075 Oct 14 23:27 fs.zip
-rwxr-xr-x 1 7331 dip       7613 Oct 14 23:27 install.sh
-rw-r--r-- 1 7331 dip         45 Oct 14 23:27 machine.conf
-rw-r--r-- 1 7331 dip       1402 Oct 14 23:27 onie-image.conf
-rw-r--r-- 1 7331 dip          0 Oct 14 23:27 platform.conf
drwxr-xr-x 2 7331 dip       2460 Oct 14 23:27 platforms
-rw-r--r-- 1 7331 dip        541 Oct 14 23:27 platforms_asic
-rw-r--r-- 1 7331 dip       1912 Oct 14 23:27 sharch_body.sh
drwxr-xr-x 2 7331 dip         80 Oct 14 23:27 tests
```

**Install the image and check if the cmdline has the parameters for a specific platforms.** 
For Eg: x86_64-mlnx_msn2100-r0  `ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="acpi_enforce_resources=lax acpi=noirq"`
https://github.com/sonic-net/sonic-buildimage/blob/master/device/mellanox/x86_64-mlnx_msn2100-r0/installer.conf i.e. 


```
root@r-bulldog-03:/home/admin# sonic-installer install ./sonic-mellanox.bin
..........
root@r-bulldog-03:/home/admin# cat /host/grub/grub.cfg
menuentry 'SONiC-OS-HEAD.1921-c8dcedad3' {
        linux   /image-HEAD.1921-c8dcedad3/boot/vmlinuz-5.10.0-12-2-amd64 root=UUID=5a177dbf-7031-43c2-994d-d3e5e26da35c  rw console=tty0 console=ttyS0,9600n8 quiet intel_idle.max_cstate=0   net.ifnames=0 biosdevname=0                 loop=image-HEAD.1921-c8dcedad3/fs.squashfs loopfstype=squashfs   systemd.unified_cgroup_hierarchy=0                 apparmor=1 security=apparmor varlog_size=4096 usbcore.autosuspend=-1 acpi_enforce_resources=lax acpi=noirq
}

root@r-bulldog-03:/home/admin# reboot 

root@r-bulldog-03:/home/admin# cat /proc/cmdline
BOOT_IMAGE=/image-HEAD.1921-c8dcedad3/boot/vmlinuz-5.10.0-12-2-amd64 root=UUID=5a177dbf-7031-43c2-994d-d3e5e26da35c rw console=tty0 console=ttyS0,9600n8 quiet intel_idle.max_cstate=0 net.ifnames=0 biosdevname=0 loop=image-HEAD.1921-c8dcedad3/fs.squashfs loopfstype=squashfs systemd.unified_cgroup_hierarchy=0 apparmor=1 security=apparmor varlog_size=4096 usbcore.autosuspend=-1 acpi_enforce_resources=lax acpi=noirq
```





#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

#### Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

