### PR TITLE
[FeatureD] Add featured systemd files in host-services

### DIFF
--- a/src/sonic-host-services-data/debian/rules
+++ b/src/sonic-host-services-data/debian/rules
@@ -15,6 +15,7 @@ build:
 override_dh_installsystemd:
 	dh_installsystemd --no-start --name=caclmgrd
 	dh_installsystemd --no-start --name=hostcfgd
+	dh_installsystemd --no-start --name=featured
 	dh_installsystemd --no-start --name=aaastatsd
 	dh_installsystemd --no-start --name=procdockerstatsd
 	dh_installsystemd --no-start --name=determine-reboot-cause

--- a/src/sonic-host-services-data/debian/sonic-host-services-data.featured.service
+++ b/src/sonic-host-services-data/debian/sonic-host-services-data.featured.service
@@ -1,0 +1,10 @@
+[Unit]
+Description==Feature configuration daemon
+Requires=updategraph.service
+After=updategraph.service
+BindsTo=sonic.target
+After=sonic.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/featured

--- a/src/sonic-host-services-data/debian/sonic-host-services-data.featured.timer
+++ b/src/sonic-host-services-data/debian/sonic-host-services-data.featured.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Delays feature daemon until SONiC has started
+PartOf=featured.service
+
+[Timer]
+OnUnitActiveSec=0 sec
+OnBootSec=1min 30 sec
+Unit=featured.service
+
+[Install]
+WantedBy=timers.target sonic.target
+


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Note: Depends on host-services PR

- Hostcfgd is handling a lot of tasks and Feature table is by itself an important and big task which can benefit from separation into a new daemon
- Currently, Hostcfgd handles feature table first before other tables an thus other taska such as Aaa, Ntp are delayed. With the split, they can run in paralell
- After the recent config-reload enhancements, Hostcfgd uses a multi-threading approach to listen to PortInitDone. BY splitting the daemon into two, we can avoid having a separate thread by using SubscriberStateTable and Select,.

#### How I did it

Refactor the feature related tasks from hostcfgd into a seperate daemon.

#### How to verify it

UT's and Tested on DUT

```
admin@r-tigris-22:~$ show logging -f | grep featured
Jun 28 22:13:33.870021 r-tigris-22 INFO featured: ConfigDB connect success
Jun 28 22:14:05.638063 r-tigris-22 INFO featured: Updating feature 'radv' systemd config file related to auto-restart ...
Jun 28 22:14:06.169184 r-tigris-22 INFO featured: Feature radv is enabled and started
Jun 28 22:14:06.172343 r-tigris-22 INFO featured: Updating feature 'sflow' systemd config file related to auto-restart ...
Jun 28 22:14:06.844322 r-tigris-22 INFO featured: Feature sflow is stopped and disabled
Jun 28 22:14:06.846761 r-tigris-22 INFO featured: Updating feature 'snmp' systemd config file related to auto-restart ...
Jun 28 22:14:07.129090 r-tigris-22 INFO featured: Feature is snmp delayed for port init
Jun 28 22:14:07.132052 r-tigris-22 INFO featured: Updating feature 'swss' systemd config file related to auto-restart ...
Jun 28 22:14:08.368948 r-tigris-22 INFO featured: Feature swss is enabled and started
Jun 28 22:14:08.369240 r-tigris-22 INFO featured: Updating feature 'syncd' systemd config file related to auto-restart ...
Jun 28 22:14:08.718357 r-tigris-22 INFO featured: Feature syncd is enabled and started
Jun 28 22:14:08.721496 r-tigris-22 INFO featured: Updating feature 'teamd' systemd config file related to auto-restart ...
Jun 28 22:14:09.042495 r-tigris-22 INFO featured: Feature teamd is enabled and started
Jun 28 22:14:09.045441 r-tigris-22 INFO featured: Updating feature 'telemetry' systemd config file related to auto-restart ...
Jun 28 22:14:09.359831 r-tigris-22 INFO featured: Feature is telemetry delayed for port init
Jun 28 22:14:30.740499 r-tigris-22 INFO featured: Updating delayed features after port initialization
Jun 28 22:14:33.914178 r-tigris-22 INFO featured: Feature lldp is enabled and started
Jun 28 22:14:35.536264 r-tigris-22 INFO featured: Feature mgmt-framework is enabled and started
Jun 28 22:14:38.098571 r-tigris-22 INFO featured: Feature snmp is enabled and started
Jun 28 22:14:39.555727 r-tigris-22 INFO featured: Feature telemetry is enabled and started


Jun 28 22:13:33.977011 r-tigris-22 INFO hostcfgd: ConfigDB connect success
Jun 28 22:13:33.993878 r-tigris-22 INFO hostcfgd: Waiting for systemctl to finish initialization
Jun 28 22:13:34.274818 r-tigris-22 INFO hostcfgd: systemctl has finished initialization -- proceeding ...
Jun 28 22:13:34.391623 r-tigris-22 INFO hostcfgd: file size check pass: /etc/pam.d/sshd size is (2139) bytes
Jun 28 22:13:34.427273 r-tigris-22 INFO hostcfgd: file size check pass: /etc/pam.d/login size is (4132) bytes
Jun 28 22:13:34.433390 r-tigris-22 INFO hostcfgd: file size check pass: /etc/nsswitch.conf size is (494) bytes
Jun 28 22:13:34.455110 r-tigris-22 INFO hostcfgd: file size check pass: /etc/nsswitch.conf size is (494) bytes
Jun 28 22:13:34.478882 r-tigris-22 INFO hostcfgd: Found audisp-tacplus PID: 442
Jun 28 22:13:34.482365 r-tigris-22 INFO hostcfgd: cmd - ['service', 'aaastatsd', 'stop']
Jun 28 22:13:36.108569 r-tigris-22 INFO hostcfgd: NtpCfg load ...
Jun 28 22:13:36.108699 r-tigris-22 INFO hostcfgd: ntp server update key 0
Jun 28 22:13:36.108763 r-tigris-22 INFO hostcfgd: ntp server update, restarting ntp-config, ntp servers configured set()
Jun 28 22:14:06.691693 r-tigris-22 INFO hostcfgd: KdumpCfg init ...
Jun 28 22:14:06.691771 r-tigris-22 DEBUG hostcfgd: passw_policies_update - key: POLICIES
Jun 28 22:14:06.691832 r-tigris-22 DEBUG hostcfgd: passw_policies_update - data: {'digits_class': 'true', 'expiration': '180', 'expiration_warning': '15', 'history_cnt': '10', 'len_min': '8', 'lower_class': 'true', 'reject_user_passw_match': 'true', 'special_class': 'true', 'state': 'disabled', 'upper_class': 'true'}
Jun 28 22:14:06.691891 r-tigris-22 DEBUG hostcfgd: modify_conf_file: passw_policies - {'digits_class': True, 'expiration': '180', 'expiration_warning': '15', 'history_cnt': '10', 'len_min': '8', 'lower_class': True, 'reject_user_passw_match': True, 'special_class': True, 'state': 'disabled', 'upper_class': True}
Jun 28 22:14:06.701982 r-tigris-22 DEBUG hostcfgd: Initial hostname: r-tigris-22
Jun 28 22:14:06.702075 r-tigris-22 DEBUG hostcfgd: Initial mgmt interface conf: {('eth0', '10.210.24.108/22'): {'gwaddr': '10.210.24.1'}}
Jun 28 22:14:06.702115 r-tigris-22 DEBUG hostcfgd: Initial mgmt VRF state: 
Jun 28 22:14:06.702177 r-tigris-22 INFO hostcfgd: RSyslogCfg: Initial config: {'config': {'GLOBAL': {'rate_limit_burst': '0', 'rate_limit_interval': '0'}}, 'servers': {}}
Jun 28 22:14:06.709455 r-tigris-22 INFO hostcfgd[39326]: Failed to restart resolv-config.service: Unit resolv-config.service not found.
Jun 28 22:14:06.709560 r-tigris-22 ERR hostcfgd: ['systemctl', 'restart', 'resolv-config'] - failed: return code - 5, output:#012None
admin@r-tigris-22:~$ Connection to r-tigris-22 closed by remote host.
```


#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

