### PR TITLE
[Nvidia] [mlnx-fw-upgrade] Always Redirect RunCmd stderr to syslog 

### DIFF
--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -23,7 +23,7 @@ function startplatform() {
 
         debug "Starting Firmware update procedure"
         /usr/bin/mst start --with_i2cdev
-        /usr/bin/mlnx-fw-upgrade.sh --verbose
+        /usr/bin/mlnx-fw-upgrade.sh
         /etc/init.d/sxdkernel restart
         debug "Firmware update procedure ended"
     fi

--- a/files/scripts/syncd.sh
+++ b/files/scripts/syncd.sh
@@ -23,7 +23,7 @@ function startplatform() {
 
         debug "Starting Firmware update procedure"
         /usr/bin/mst start --with_i2cdev
-        /usr/bin/mlnx-fw-upgrade.sh
+        /usr/bin/mlnx-fw-upgrade.sh --verbose
         /etc/init.d/sxdkernel restart
         debug "Firmware update procedure ended"
     fi

--- a/platform/mellanox/mlnx-fw-upgrade.j2
+++ b/platform/mellanox/mlnx-fw-upgrade.j2
@@ -191,11 +191,7 @@ function GetMstDevice() {
 function RunCmd() {
     local ERROR_CODE="${EXIT_SUCCESS}"
 
-    if [[ "${VERBOSE_LEVEL}" -eq "${VERBOSE_MAX}" ]]; then
-        eval "$@"
-    else
-        eval "$@" &>/dev/null
-    fi
+    eval "$@"
 
     ERROR_CODE="$?"
     if [[ "${ERROR_CODE}" != "${EXIT_SUCCESS}" ]]; then


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

When mlxfwquery fails during fw-upgrade script, no error is logged on why it is failed

```
Jun 27 07:23:36.199278 sonic INFO syncd.sh[10498]: ERROR: command failed: mlxfwmanager --query -o /tmp/mlxfwmanager-query.log
Jun 27 07:23:36.202764 sonic ERR mlnx-fw-upgrade.sh: command failed: mlxfwmanager --query -o /tmp/mlxfwmanager-query.log
```

#### How I did it

RunCmd is used with Query and list-content and both of which redirect any useful output to the file specified by the -o arg.
When not run in verbose mode, the stderr is redirected to /dev/null and thus update to always redirect any stderr to syslog


#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

