### PR TITLE
[Nvidia] Dont use dkms mkbmdeb to build the mft package

### DIFF
--- a/platform/mellanox/mft/Makefile
+++ b/platform/mellanox/mft/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016-2021 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2016-2023 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,13 +39,24 @@ MOD_DEB = kernel-mft-dkms-modules-$(KVERSION)_$(MFT_VERSION)_$(CONFIGURED_ARCH).
 MAIN_TARGET = mft_$(MFT_VERSION)-$(MFT_REVISION)_$(CONFIGURED_ARCH).deb
 DERIVED_TARGETS = $(MOD_DEB) mft-oem_$(MFT_VERSION)-$(MFT_REVISION)_$(CONFIGURED_ARCH).deb
 
-DKMS_BMDEB = /var/lib/dkms/kernel-mft-dkms/$(MFT_VERSION)/bmdeb
+DKMS_CTRL = /var/lib/dkms/kernel-mft-dkms/
 DKMS_TMP := $(shell mktemp -u -d -t dkms.XXXXXXXXXX)
 
 $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	rm -rf $(MFT_NAME)
 	wget -O $(MFT_TGZ) $(MFT_TGZ_URL)
 	tar xzf $(MFT_TGZ)
+
+	# Prepare the directory to build kernel-mft-dkms-modules debian package
+	mkdir -p $(DKMS_TMP)/DEBIAN
+	mkdir -p $(DKMS_TMP)/lib/modules/$(KVERSION)/updates/dkms/
+	export kversion="$(KVERSION)"
+	export mft_version="$(MFT_VERSION)"
+	j2 templates/control.j2 > $(DKMS_TMP)/DEBIAN/control
+	j2 templates/postinst.j2 > $(DKMS_TMP)/DEBIAN/postinst
+	j2 templates/postrm.j2 > $(DKMS_TMP)/DEBIAN/postrm
+	chmod +x $(DKMS_TMP)/DEBIAN/postinst
+	chmod +x $(DKMS_TMP)/DEBIAN/postrm
 
 	pushd $(MFT_NAME)/SDEBS
 
@@ -59,15 +70,10 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	popd
 
 	sudo dkms build kernel-mft-dkms/$(MFT_VERSION) -k $(KVERSION) -a $(CONFIGURED_ARCH)
-	sudo dkms mkbmdeb kernel-mft-dkms/$(MFT_VERSION) -k $(KVERSION) -a $(CONFIGURED_ARCH)
 
-	# w/a: remove dependencies
-	mkdir -p $(DKMS_TMP)/DEBIAN
-
-	dpkg -e $(DKMS_BMDEB)/$(MOD_DEB) $(DKMS_TMP)/DEBIAN
-	dpkg -x $(DKMS_BMDEB)/$(MOD_DEB) $(DKMS_TMP)
-
-	sed -i '/^Depends:/c\Depends:' $(DKMS_TMP)/DEBIAN/control
+	# copy the built modules
+	cp -r $(DKMS_CTRL)/kernel-$(KVERSION)-$(CONFIGURED_ARCH)/module/*.ko \
+			$(DKMS_TMP)/lib/modules/$(KVERSION)/updates/dkms/
 
 	pushd $(MFT_NAME)/DEBS
 	dpkg -b $(DKMS_TMP) .

--- a/platform/mellanox/mft/templates/control.j2
+++ b/platform/mellanox/mft/templates/control.j2
@@ -1,0 +1,9 @@
+Package: kernel-mft-dkms-modules-{{kversion}}
+Source: kernel-mft-dkms-dkms-bin
+Version: {{mft_version}}
+Architecture: amd64
+Maintainer: Vivek Reddy <vkarri@nvidia.com>
+Provides: kernel-mft-dkms-modules
+Section: misc
+Priority: optional
+Description: kernel-mft-dkms binary drivers for linux-image-{{kversion}} Kernel

--- a/platform/mellanox/mft/templates/postinst.j2
+++ b/platform/mellanox/mft/templates/postinst.j2
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+depmod -a {{kversion}}

--- a/platform/mellanox/mft/templates/postrm.j2
+++ b/platform/mellanox/mft/templates/postrm.j2
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+depmod -a {{kversion}}


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

mkbmdeb is deprecated in Bookworm. Thus moving away from the command to build the package.

#### How I did it

Packaged the mft dkms modules by creating the required debian files and copying the modules to the expected location.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

```
vkarri@builld:$ dpkg -c target/debs/bookworm/kernel-mft-dkms-modules-6.1.0-11-2-amd64_4.25.0_amd64.deb 
drwxr-xr-x vkarri/dip        0 2023-09-20 00:38 ./
drwxr-xr-x vkarri/dip        0 2023-09-20 00:38 ./lib/
drwxr-xr-x vkarri/dip        0 2023-09-20 00:38 ./lib/modules/
drwxr-xr-x vkarri/dip        0 2023-09-20 00:38 ./lib/modules/6.1.0-11-2-amd64/
drwxr-xr-x vkarri/dip        0 2023-09-20 00:38 ./lib/modules/6.1.0-11-2-amd64/updates/
drwxr-xr-x vkarri/dip        0 2023-09-20 00:38 ./lib/modules/6.1.0-11-2-amd64/updates/dkms/
-rw-r--r-- vkarri/dip    79029 2023-09-20 00:38 ./lib/modules/6.1.0-11-2-amd64/updates/dkms/mst_pci.ko
-rw-r--r-- vkarri/dip    77717 2023-09-20 00:38 ./lib/modules/6.1.0-11-2-amd64/updates/dkms/mst_pciconf.ko
```

Install and check if the modules are loaded

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

