### PR TITLE
Fix kdump-tools to not overwrite MODULES conf to dep

### DIFF
--- a/src/kdump-tools/patch/0003-Revert-the-MODULES-dep-optimization.patch
+++ b/src/kdump-tools/patch/0003-Revert-the-MODULES-dep-optimization.patch
@@ -1,0 +1,35 @@
+From 9f15d2abc8c39bc6eae6ffaccbb3a5d9d4fa84b8 Mon Sep 17 00:00:00 2001
+From: Vivek Reddy <vkarri@nvidia.com>
+Date: Tue, 12 Dec 2023 11:15:54 +0200
+Subject: [PATCH] Revert the MODULES=dep optimization to reduce the size of initramfs
+
+kdump-tools command is failing in chroot because of this optimization
+Overriding the MODULES to dep is causing mkinitramfs to search for the 
+block device where the / is mounted
+Ref: https://www.mail-archive.com/kernel-packages@lists.launchpad.net/msg515013.html
+
+Signed-off-by: Vivek Reddy <vkarri@nvidia.com>
+---
+ debian/kernel-postinst-generate-initrd | 6 ------
+ 1 file changed, 6 deletions(-)
+
+diff --git a/debian/kernel-postinst-generate-initrd b/debian/kernel-postinst-generate-initrd
+index 1140c40..96a0f15 100755
+--- a/debian/kernel-postinst-generate-initrd
++++ b/debian/kernel-postinst-generate-initrd
+@@ -40,12 +40,6 @@ for conf_file in /etc/initramfs-tools/conf.d/*; do
+ 	fi
+ done
+ 
+-if test "${MODULES-most}" = most; then
+-	# Switch from "most" to "dep" to reduce the size of the initramfs.
+-	# "netboot" and "list" are expected to be already small enough.
+-	KDUMP_MODULES=dep
+-fi
+-
+ # We need a modified copy of initramfs-tools directory
+ # with MODULES=dep in initramfs.conf
+ if [ ! -d "$kdumpdir" ];then
+-- 
+2.41.0
+

--- a/src/kdump-tools/patch/series
+++ b/src/kdump-tools/patch/series
@@ -1,1 +1,2 @@
 0002-core-file-prefixed-by-kdump.patch
+0003-Revert-the-MODULES-dep-optimization.patch


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Fix kdump-tools to not overwrite MODULES conf to dep. Problem is seen if the build is failed and the build is retriggered immediately as part of retry mechanism
This command is failing during the second run

```
+ for kernel_release in $(ls $FILESYSTEM_ROOT/lib/modules/)
+ sudo LANG=C chroot ./fsroot-mellanox /etc/kernel/postinst.d/kdump-tools 6.1.0-11-2-amd64
+ clean_sys
```
https://github.com/sonic-net/sonic-buildimage/blob/master/files/build_templates/sonic_debian_extension.j2#L311

Community Issue: https://www.mail-archive.com/kernel-packages@lists.launchpad.net/msg515013.html

#### How I did it

Add a patch to revert the override

#### How to verify it

```
vkarri@482a053c44f4:/sonic$ sudo unsquashfs -d ./fsroot-mellanox target/sonic-mellanox.bin__mellanox__rfs.squashfs
vkarri@482a053c44f4:/sonic$ sudo DEBIAN_FRONTEND=noninteractive dpkg --root=./fsroot-mellanox -i target/debs/bookworm/kdump-tools_1.8.1_amd64.de

vkarri@482a053c44f4:/sonic$ sudo LANG=C chroot ./fsroot-mellanox mount proc /proc -t proc
vkarri@482a053c44f4:/sonic$ sudo LANG=C chroot ./fsroot-mellanox mount sysfs /sys -t sysfs
```

**Before the fix:**
```
vkarri@482a053c44f4:/sonic$ sudo LANG=C chroot ./fsroot-mellanox /etc/kernel/postinst.d/kdump-tools 6.1.0-11-2-amd64
kdump-tools: Generating /var/lib/kdump/initrd.img-6.1.0-11-2-amd64
mkinitramfs: failed to determine device for /
mkinitramfs: workaround is MODULES=most, check:
grep -r MODULES /var/lib/kdump/initramfs-tools
Error please report bug on initramfs-tools
Include the output of 'mount' and 'cat /proc/mounts'

vkarri@482a053c44f4:/sonic$ echo $?
1
```


**With the patch:**
```
vkarri@482a053c44f4:/sonic$ sudo LANG=C chroot ./fsroot-mellanox /etc/kernel/postinst.d/kdump-tools 6.1.0-11-2-amd64
kdump-tools: Generating /var/lib/kdump/initrd.img-6.1.0-11-2-amd64

vkarri@482a053c44f4:/sonic$ echo $?
0
```
<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

