### PR TITLE
Add log files into the cache tar for improved debugging

### DIFF
--- a/Makefile.cache
+++ b/Makefile.cache
@@ -283,7 +283,7 @@ define SAVE_INTO_CACHE
 	$(call GET_MOD_SHA,$(1))
 
 	# Form the cache file name
-	$(eval $(1)_MOD_CACHE_FILE  := $(1)-$($(1)_DEP_MOD_SHA)-$($(1)_MOD_HASH).tgz)
+	$(eval $(1)_MOD_CACHE_FILE  := $(1)-$($(1)_DEP_MOD_SHA)-$($(1)_MOD_HASH))
 	$(if $(MDEBUG), $(info $(1)_MOD_CACHE_FILE := $($(1)_MOD_CACHE_FILE)))
 
 	# Retrive and log files list that are modified for the target.
@@ -295,12 +295,16 @@ define SAVE_INTO_CACHE
 		echo "Target $(1) dependencies are modifed - global save cache skipped" >> $($(1)_DST_PATH)/$(1).log
 		$(eval $(1)_CACHE_DIR := $(SONIC_DPKG_LOCAL_CACHE_DIR))
 	 )
-	$($(1)_CACHE_USER) tar -C $($(1)_BASE_PATH) -mczvf $($(1)_CACHE_DIR)/$(MOD_CACHE_FILE) $(2) $(addprefix $($(1)_DST_PATH)/,$($(1)_DERIVED_DEBS) $($(1)_EXTRA_DEBS) )  \
+	$($(1)_CACHE_USER) tar -C $($(1)_BASE_PATH) -mcvf $($(1)_CACHE_DIR)/$(MOD_CACHE_FILE).tar $(2) $(addprefix $($(1)_DST_PATH)/,$($(1)_DERIVED_DEBS) $($(1)_EXTRA_DEBS) )  \
 		1>>$($(1)_DST_PATH)/$(1).log
-	sudo chmod 777 $($(1)_CACHE_DIR)/$(MOD_CACHE_FILE)
 
 	echo "File $($(1)_CACHE_DIR)/$(MOD_CACHE_FILE) saved in cache " >> $($(1)_DST_PATH)/$(1).log
 	echo "[ CACHE::SAVED ] $($(1)_CACHE_DIR)/$(MOD_CACHE_FILE)" >> $($(1)_DST_PATH)/$(1).log
+
+	$($(1)_CACHE_USER) tar -C $($(1)_BASE_PATH) -muvf $($(1)_CACHE_DIR)/$(MOD_CACHE_FILE).tar $($(1)_DST_PATH)/$(1).log
+	$($(1)_CACHE_USER) gzip -9 $($(1)_CACHE_DIR)/$(MOD_CACHE_FILE).tar
+	$($(1)_CACHE_USER) mv $($(1)_CACHE_DIR)/$(MOD_CACHE_FILE).tar.gz $($(1)_CACHE_DIR)/$(MOD_CACHE_FILE).tgz
+	sudo chmod 777 $($(1)_CACHE_DIR)/$(MOD_CACHE_FILE).tgz
 
 	$(call MOD_UNLOCK,$(1))
 endef

--- a/Makefile.cache
+++ b/Makefile.cache
@@ -302,7 +302,7 @@ define SAVE_INTO_CACHE
 	echo "[ CACHE::SAVED ] $($(1)_CACHE_DIR)/$(MOD_CACHE_FILE)" >> $($(1)_DST_PATH)/$(1).log
 
 	$($(1)_CACHE_USER) tar -C $($(1)_BASE_PATH) -muvf $($(1)_CACHE_DIR)/$(MOD_CACHE_FILE).tar $($(1)_DST_PATH)/$(1).log
-	$($(1)_CACHE_USER) gzip -9 $($(1)_CACHE_DIR)/$(MOD_CACHE_FILE).tar
+	$($(1)_CACHE_USER) gzip $($(1)_CACHE_DIR)/$(MOD_CACHE_FILE).tar
 	$($(1)_CACHE_USER) mv $($(1)_CACHE_DIR)/$(MOD_CACHE_FILE).tar.gz $($(1)_CACHE_DIR)/$(MOD_CACHE_FILE).tgz
 	sudo chmod 777 $($(1)_CACHE_DIR)/$(MOD_CACHE_FILE).tgz
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Cache currently does not save the log of the deb. But it's useful to have the log to understand any cache related problems.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

```
vkarri@s-build-sonic-01:/sonic-buildimage$ tar -tvf /sonic/sonic_caches/libnl-3-200_3.5.0-1_amd64.deb-adc83b19e793491b1c6ea0f-0ea77d65c49ae3a11dffbca.tgz
-rw-r--r-- vkarri/dip   496230 2024-01-12 19:49 target/debs/bookworm/libnl-3-200_3.5.0-1_amd64.deb.log
```

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

