### PR TITLE
[Mellanox] Disable SGX for SN5600/SN5400 platforms

### DIFF
--- a/device/mellanox/x86_64-nvidia_sn5400-r0/installer.conf
+++ b/device/mellanox/x86_64-nvidia_sn5400-r0/installer.conf
@@ -1,1 +1,1 @@
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="modprobe.blacklist=tpm_tis,tpm_crb,tpm"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="modprobe.blacklist=tpm_tis,tpm_crb,tpm nosgx"

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/installer.conf
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/installer.conf
@@ -1,1 +1,1 @@
-ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="libata.force=noncq modprobe.blacklist=tpm_tis,tpm_crb,tpm"
+ONIE_PLATFORM_EXTRA_CMDLINE_LINUX="libata.force=noncq modprobe.blacklist=tpm_tis,tpm_crb,tpm nosgx"


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Booting master/202405 images on SN5400 and SN5600 platforms is resulting the log

```
2024-07-23T21:01:07.972045+00:00 sonic kernel: [    0.110657] x86/cpu: SGX disabled by BIOS.
2024-07-23T21:01:07.972045+00:00 sonic kernel: [    0.110657] x86/cpu: SGX disabled by BIOS.
```

Processor on these systems supports the SGX but the BIOS does not. SGX feature is also not important and thus disable using the nosgx kernel boot parameter

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

Added the parameter, reboot and check for log

