### PR TITLE
Enable linux capabilities on sflow container for kernel 6.1.94 compatibility

### DIFF
--- a/rules/docker-sflow.mk
+++ b/rules/docker-sflow.mk
@@ -30,7 +30,7 @@ SONIC_INSTALL_DOCKER_DBG_IMAGES += $(DOCKER_SFLOW_DBG)
 endif
 
 $(DOCKER_SFLOW)_CONTAINER_NAME = sflow
-$(DOCKER_SFLOW)_RUN_OPT += -t
+$(DOCKER_SFLOW)_RUN_OPT += -t --cap-add=NET_ADMIN --cap-add=SYS_ADMIN
 $(DOCKER_SFLOW)_RUN_OPT += -v /etc/sonic:/etc/sonic:ro
 $(DOCKER_SFLOW)_RUN_OPT += -v /etc/timezone:/etc/timezone:ro 
 $(DOCKER_SFLOW)_RUN_OPT += -v /host/warmboot:/var/warmboot


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Starting 6.1.94, Kernel mandates the process to have SYS_ADMIN/NET_ADMIN capability to join events/packets multicast group respectively PSAMPLE used packets and DROPMON uses events

Ref:
https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=e03781879a0d https://git.kernel.org/pub/scm/linux/kernel/git/netdev/net.git/commit/?id=44ec98ea5ea9

Without this, the following error is observed and host-sflow couldn't use psample and NET_DB

```
2024 Jul 24 22:38:35.140784 r-tigris-04 ERR sflow#hsflowd: error joining PSAMPLE netlink group 20 : Operation not permitted
2024 Jul 24 22:38:35.849822 r-tigris-04 ERR sflow#hsflowd: error joining DROPMON netlink group 1 : Operation not permitted
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

Verify the sflow functionality with linux update and this fix

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

