### PR TITLE
[nvidia-bluefield] Differentiate cache based on compilation and download

### DIFF
--- a/platform/nvidia-bluefield/recipes/sdk.dep
+++ b/platform/nvidia-bluefield/recipes/sdk.dep
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+# Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-SDK_COMMON_FLAGS_LIST = $(SONIC_COMMON_FLAGS_LIST) $(SDK_VERSION)
+SDK_COMMON_FLAGS_LIST = $(SONIC_COMMON_FLAGS_LIST) $(SDK_VERSION) $(SDK_FROM_SRC)
 SDK_COMMON_FILES_LIST = $(SONIC_COMMON_BASE_FILES_LIST) \
 	$(SONIC_COMMON_FILES_LIST) \
 	$(PLATFORM_PATH)/recipes/sdk.mk \


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Image compilation fails when using the same cache tar for build from source and download from artifact. 

Eg:
When building from sources, mlnx-tools is a derived package of mlnx-ofed-kernel-utils and the cache tar has both the packages saved
```
$ tar -tvf  mlnx-tools_25.01-0.2501060_arm64.deb-adc83b19e793491b1c6ea0f-ba387afe3cf420ba021052c.tgz
-rw-r--r-- vkarri/dip    69712 2025-06-11 02:24 target/debs/bookworm/mlnx-tools_25.01-0.2501060_arm64.deb
-rw-r--r-- vkarri/dip    27816 2025-06-11 02:25 target/debs/bookworm/mlnx-ofed-kernel-utils_25.01.OFED.25.01.0.6.0.1-1_arm64.deb
-rw-r--r-- vkarri/dip  2445612 2025-06-11 02:25 target/debs/bookworm/mlnx-ofed-kernel-dkms_25.01.OFED.25.01.0.6.0.1-1_all.deb
-rw-r--r-- vkarri/dip    73036 2025-06-11 02:25 target/debs/bookworm/mlnx-tools_25.01-0.2501060_arm64.deb.cached.log
```

When downloading from source and enabling caching would cause the cache only to have mlnx-tools package
```
$ tar -tvf mlnx-tools_25.01-0.2501060_arm64.deb-adc83b19e793491b1c6ea0f-27f1acbefcfdfd078f9632c.tgz
-rw-r--r-- vkarri/dip    69712 2025-06-11 02:11 target/debs/bookworm/mlnx-tools_25.01-0.2501060_arm64.deb
-rw-r--r-- vkarri/dip      997 2025-06-11 02:11 target/debs/bookworm/mlnx-tools_25.01-0.2501060_arm64.deb.cached.log
```

Now image the following steps

1. Enable cache, Fetch from artifactory and build a sonic image
2. Use the same cache and build from sonic image using source compilation strategy(mlnx-tools cache in the previous step is picked)

```
05:44:06  [ building ] [ target/debs/bookworm/mlnx-ofed-kernel-utils_25.01.OFED.25.01.0.6.0.1-1_arm64.deb ] 
05:44:06  [ finished ] [ target/debs/bookworm/mlnx-ofed-kernel-utils_25.01.OFED.25.01.0.6.0.1-1_arm64.deb ] 
05:44:10  [ building ] [ target/debs/bookworm/mlnx-ofed-kernel-utils_25.01.OFED.25.01.0.6.0.1-1_arm64.deb-install ] 
05:44:10  [ finished ] [ target/debs/bookworm/mlnx-ofed-kernel-utils_25.01.OFED.25.01.0.6.0.1-1_arm64.deb-install ] 
05:44:10  [ FAIL LOG START ] [ target/debs/bookworm/mlnx-ofed-kernel-utils_25.01.OFED.25.01.0.6.0.1-1_arm64.deb-install ]
05:44:10  Build start time: Tue Jun 10 02:44:09 UTC 2025
05:44:10  target/debs/bookworm/mlnx-ofed-kernel-utils_25.01.OFED.25.01.0.6.0.1-1_arm64.deb does not exist
05:44:10  [  FAIL LOG END  ] [ target/debs/bookworm/mlnx-ofed-kernel-utils_25.01.OFED.25.01.0.6.0.1-1_arm64.deb-install ]
05:44:10  make: *** [slave.mk:869: target/debs/bookworm/mlnx-ofed-kernel-utils_25.01.OFED.25.01.0.6.0.1-1_arm64.deb-install] Error 1
05:44:10  make: *** Waiting for unfinished jobs...
``` 

#### How I did it

Differentiate cache based on the compilation strategy

#### How to verify it

Verify if the above flow succeeds

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

