### PR TITLE
Log the error in case of failed ONIE update

### DIFF
--- a/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
+++ b/platform/mellanox/mlnx-platform-api/sonic_platform/component.py
@@ -1,5 +1,6 @@
 #
-# Copyright (c) 2019-2024 NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: NVIDIA CORPORATION & AFFILIATES
+# Copyright (c) 2019-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,6 +31,7 @@ try:
     import tempfile
     import subprocess
     from sonic_py_common import device_info
+    from sonic_py_common.logger import Logger
     from sonic_py_common.general import check_output_pipe
     if sys.version_info[0] > 2:
         import configparser
@@ -49,6 +51,7 @@ try:
 except ImportError as e:
     raise ImportError(str(e) + "- required module not found")
 
+logger = Logger("mlnx-platform-api")
 
 class MPFAManager(object):
     MPFA_EXTENSION = '.mpfa'
@@ -669,6 +672,7 @@ class ComponentBIOS(Component):
             print("INFO: Staging {} firmware update with ONIE updater".format(self.name))
             self.onie_updater.update_firmware(image_path, allow_reboot)
         except Exception as e:
+            logger.log_warning("Failed to update {} firmware: {}".format(self.name, str(e)))
             print("ERROR: Failed to update {} firmware: {}".format(self.name, str(e)))
             return False
 


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

