### PR TITLE
[nvidia-bluefield] Fix clock skew build failure

### DIFF
--- a/platform/nvidia-bluefield/sdk-src/nv_hws/Makefile
+++ b/platform/nvidia-bluefield/sdk-src/nv_hws/Makefile
@@ -34,7 +34,11 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	unzip nv_hws.zip
 
 	pushd nv_hws/
+
+	find . -type f -exec touch {} +
+
 	PATH=/usr/bin/:$(PATH) dpkg-buildpackage -d -us -uc -b -j1 --admindir $(SONIC_DPKG_ADMINDIR)
+
 	popd
 
 	mv $(DERIVED_TARGETS) $* $(DEST)/


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Because of the missing change, on build servers where the clock is not synced, it might lead to build failure

```
ERROR: Clock skew detected. File /sonic/platform/nvidia-bluefield/sdk-src/nv_hws/nv_hws/obj-aarch64-linux-gnu/../meson.build has a time stamp 10428.1250s in the future.
dh_auto_configure: error: cd obj-aarch64-linux-gnu && LC_ALL=C.UTF-8 meson setup .. --wrap-mode=nodownload --buildtype=plain --prefix=/usr --sysconfdir=/etc --localstatedir=/var --libdir=lib/aarch64-linux-gnu --buildtype=release -Ddefault_library=both -Db_lto=true -Dflexio=disabled returned exit code 1
```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

Build is successful

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

