### PR TITLE
[DPU] Increase Bulker limit and pop batch size

### DIFF
--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -18,22 +18,25 @@ fi
 mkdir -p /var/log/swss
 ORCHAGENT_ARGS="-d /var/log/swss "
 
+SWITCH_TYPE=$(echo $SWSS_VARS | jq -r '.switch_type')
 LOCALHOST_SWITCHTYPE=`sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "switch_type"`
 if [[ x"${LOCALHOST_SWITCHTYPE}" == x"chassis-packet" ]]; then
     # Set orchagent pop batch size to 128 for faster link notification handling 
     # during route-churn
     ORCHAGENT_ARGS+="-b 128 "
-else
+elif [ "$SWITCH_TYPE" != "dpu" ]; then
     # Set orchagent pop batch size to 1024
     ORCHAGENT_ARGS+="-b 1024 "
+else
+    # To handle high volume of objects in DPU
+    ORCHAGENT_ARGS+="-b 65536 "
 fi
 
-# Set zmq mode by default for smartswitch DPU
+# Set zmq mode by default for smartswitch DPU and increase the max bulk limit
 # Otherwise, set synchronous mode if it is enabled in CONFIG_DB
 SYNC_MODE=$(echo $SWSS_VARS | jq -r '.synchronous_mode')
-SWITCH_TYPE=$(echo $SWSS_VARS | jq -r '.switch_type')
 if [ "$SWITCH_TYPE" == "dpu" ]; then
-    ORCHAGENT_ARGS+="-z zmq_sync "
+    ORCHAGENT_ARGS+="-z zmq_sync -k 65536 "
 elif [ "$SYNC_MODE" == "enable" ]; then
     ORCHAGENT_ARGS+="-s "
 fi

--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -18,13 +18,12 @@ fi
 mkdir -p /var/log/swss
 ORCHAGENT_ARGS="-d /var/log/swss "
 
-SWITCH_TYPE=$(echo $SWSS_VARS | jq -r '.switch_type')
 LOCALHOST_SWITCHTYPE=`sonic-db-cli CONFIG_DB hget "DEVICE_METADATA|localhost" "switch_type"`
 if [[ x"${LOCALHOST_SWITCHTYPE}" == x"chassis-packet" ]]; then
     # Set orchagent pop batch size to 128 for faster link notification handling 
     # during route-churn
     ORCHAGENT_ARGS+="-b 128 "
-elif [ "$SWITCH_TYPE" == "dpu" ]; then
+elif [[ x"$LOCALHOST_SWITCHTYPE" == x"dpu" ]]; then
     # To handle high volume of objects in DPU
     ORCHAGENT_ARGS+="-b 65536 "
 else
@@ -35,7 +34,7 @@ fi
 # Set zmq mode by default for smartswitch DPU and increase the max bulk limit
 # Otherwise, set synchronous mode if it is enabled in CONFIG_DB
 SYNC_MODE=$(echo $SWSS_VARS | jq -r '.synchronous_mode')
-if [ "$SWITCH_TYPE" == "dpu" ]; then
+if [ "$LOCALHOST_SWITCHTYPE" == "dpu" ]; then
     ORCHAGENT_ARGS+="-z zmq_sync -k 65536 "
 elif [ "$SYNC_MODE" == "enable" ]; then
     ORCHAGENT_ARGS+="-s "

--- a/dockers/docker-orchagent/orchagent.sh
+++ b/dockers/docker-orchagent/orchagent.sh
@@ -24,12 +24,12 @@ if [[ x"${LOCALHOST_SWITCHTYPE}" == x"chassis-packet" ]]; then
     # Set orchagent pop batch size to 128 for faster link notification handling 
     # during route-churn
     ORCHAGENT_ARGS+="-b 128 "
-elif [ "$SWITCH_TYPE" != "dpu" ]; then
-    # Set orchagent pop batch size to 1024
-    ORCHAGENT_ARGS+="-b 1024 "
-else
+elif [ "$SWITCH_TYPE" == "dpu" ]; then
     # To handle high volume of objects in DPU
     ORCHAGENT_ARGS+="-b 65536 "
+else
+    # Set orchagent pop batch size to 1024
+    ORCHAGENT_ARGS+="-b 1024 "
 fi
 
 # Set zmq mode by default for smartswitch DPU and increase the max bulk limit


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Increase the pop batch size and Max Bulker limit to 65536 to speed up applying the high volume Dash configuration

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

```
root@sonic:/home/admin# ps -aux | grep orch
root       11118  1.5  0.4 464804 267368 pts/0   Sl   02:50   0:00 /usr/bin/orchagent -d /var/log/swss -b 65536 -z zmq_sync -k 65536 -m B0:CF:0E:20:8E:DE -q tcp://eth0-midplane

2025 Sep 30 18:48:38.911835 sonic NOTICE swss#orchagent: :- main: Setting maximum bulk size in bulk mode as 65536
```

Apply Scale config and verify

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202205
- [ ] 202211
- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

