### PR TITLE
[Nvidia-Bluefield] Update NASA/SAI to 26.4-RC8/SAIBuild0.0.56.0

### DIFF
--- a/platform/nvidia-bluefield/recipes/dpu-sai.mk
+++ b/platform/nvidia-bluefield/recipes/dpu-sai.mk
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-DPU_SAI_VERSION = SAIBuild0.0.55.0
+DPU_SAI_VERSION = SAIBuild0.0.56.0
 
 # Place here URL where SAI sources exist
 DPU_SAI_SOURCE_BASE_URL=

--- a/platform/nvidia-bluefield/recipes/dpu-sai.mk
+++ b/platform/nvidia-bluefield/recipes/dpu-sai.mk
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-DPU_SAI_VERSION = SAIBuild0.0.53.0
+DPU_SAI_VERSION = SAIBuild0.0.55.0
 
 # Place here URL where SAI sources exist
 DPU_SAI_SOURCE_BASE_URL=

--- a/platform/nvidia-bluefield/recipes/sdk.mk
+++ b/platform/nvidia-bluefield/recipes/sdk.mk
@@ -20,7 +20,7 @@ SDK_BASE_PATH = $(PLATFORM_PATH)/sdk-src/sonic-bluefield-packages/bin
 
 # Place here URL where SDK sources exist
 SDK_SOURCE_BASE_URL =
-SDK_VERSION = 26.4-RC7
+SDK_VERSION = 26.4-RC8
 
 SDK_COLLECTX_URL = https://linux.mellanox.com/public/repo/doca/1.5.2/debian12/aarch64/
 

--- a/platform/nvidia-bluefield/recipes/sdk.mk
+++ b/platform/nvidia-bluefield/recipes/sdk.mk
@@ -20,7 +20,7 @@ SDK_BASE_PATH = $(PLATFORM_PATH)/sdk-src/sonic-bluefield-packages/bin
 
 # Place here URL where SDK sources exist
 SDK_SOURCE_BASE_URL =
-SDK_VERSION = 26.4-RC4
+SDK_VERSION = 26.4-RC7
 
 SDK_COLLECTX_URL = https://linux.mellanox.com/public/repo/doca/1.5.2/debian12/aarch64/
 

--- a/platform/nvidia-bluefield/sdk-src/dpdk/0001-Remove-linux-headers-dependency.patch
+++ b/platform/nvidia-bluefield/sdk-src/dpdk/0001-Remove-linux-headers-dependency.patch
@@ -1,0 +1,25 @@
+From 8da84852bf24f69f9b371aed97f99fdafc423323 Mon Sep 17 00:00:00 2001
+From: Vivek Reddy <vkarri@nvidia.com>
+Date: Tue, 30 Jun 2026 21:06:42 +0300
+Subject: [PATCH] Remove linux headers dependency
+
+Signed-off-by: Vivek Reddy <vkarri@nvidia.com>
+---
+ debian/control | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/debian/control b/debian/control
+index 3dbe044..afbf134 100644
+--- a/debian/control
++++ b/debian/control
+@@ -17,7 +17,6 @@ Build-Depends: debhelper (>= 10.3~),
+                libssl-dev,
+                linux-headers-686 [i386] | linux-headers-generic [i386],
+                linux-headers-amd64 [amd64] | linux-headers-generic [amd64],
+-               linux-headers-arm64 [arm64] | linux-headers-generic [arm64],
+                linux-headers-armmp [armhf] | linux-headers-generic [armhf],
+                linux-headers-powerpc64le [ppc64el] | linux-headers-generic [ppc64el],
+                meson (>= 0.41~),
+-- 
+2.49.0
+

--- a/platform/nvidia-bluefield/sdk-src/dpdk/Makefile
+++ b/platform/nvidia-bluefield/sdk-src/dpdk/Makefile
@@ -33,6 +33,8 @@ $(addprefix $(DEST)/, $(MAIN_TARGET)): $(DEST)/% :
 	pushd dpdk.org/
 	find . -type f -exec touch {} +
 
+	patch -p1 < ../0001-Remove-linux-headers-dependency.patch
+
 	# Build the package
 	# PATH variable is required for ninja to find the right version
 	DPDK_CONFIG_OPTIONS='--cross-file ../config/arm/arm64_bluefield_linux_gcc -Dpkt_mbuf_headroom=256' dpkg-buildpackage -us -uc -b -j$(SONIC_CONFIG_MAKE_JOBS) --admindir $(SONIC_DPKG_ADMINDIR)


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

Update the Nvidia BlueField DPU SONiC build to the latest NASA / SAI (NASA 26.4-RC8 / SAIBuild 0.0.56.0)

Specifically:

- Move DPU SAI / SDK recipes to NASA 26.4-RC8 and SAIBuild 0.0.56.0.
- Fix DPDK compilation issues by removing linux headers dependency


##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

Run  DASH traffic sanity and HA tests

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 202305
- [ ] 202311
- [ ] 202405
- [ ] 202411
- [ ] 202505
- [ ] 202511

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

